### PR TITLE
feat: add layout component with polished header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,83 @@
+# TransferPro – Global Money Transfer UI
+
+A Vite + React + TypeScript single-page application that showcases a global money transfer experience. The interface highlights competitive currency conversion, onboarding flows, and account management hooks while using modern tooling for state, data, and theme management.
+
+## Features
+- **Hero landing page:** Marketing headline, conversion CTAs, and quick stats rendered with reusable UI primitives (`Hero`).
+- **Interactive currency converter:** Supports currency selection, swap, transfer fee breakdown, and invokes transfer creation through Redux Toolkit/React Query powered actions (`CurrencyConverter`).
+- **Guided transfer steps:** Responsive cards outlining the three-step send flow with live completion stats driven by mocked transfer data (`TransferSteps`).
+- **State & data layer:** Redux Toolkit slices for auth and transfer domains combined with TanStack Query for caching, mutations, and background revalidation (`useAuth`, `useTransfers`).
+- **API abstractions:** REST and GraphQL clients with MSW-powered mocks to simulate login, transfer, recipient, and exchange-rate endpoints during development.
+- **Design system:** Tailwind CSS and shadcn/ui components (buttons, cards, badges, inputs, etc.) with dark/light theme switching via `next-themes`.
+
+## Tech Stack
+- [Vite](https://vitejs.dev/) for lightning-fast dev server and build pipeline
+- [React 18](https://react.dev/) with [TypeScript](https://www.typescriptlang.org/)
+- [React Router](https://reactrouter.com/) for client-side routing
+- [Redux Toolkit](https://redux-toolkit.js.org/) and [React Redux](https://react-redux.js.org/) for global state management
+- [TanStack Query](https://tanstack.com/query/latest) for server-state caching and mutations
+- [Apollo Client](https://www.apollographql.com/docs/react/) for optional GraphQL interactions
+- [MSW](https://mswjs.io/) for API mocking in development
+- [Tailwind CSS](https://tailwindcss.com/) and [shadcn/ui](https://ui.shadcn.com/) component patterns for styling
+- [lucide-react](https://lucide.dev/) iconography
+
+## Project Structure
+```
+├── public/                 # Static assets served by Vite
+├── src/
+│   ├── App.tsx             # Route configuration
+│   ├── pages/              # Route-level components (Index, NotFound)
+│   ├── components/
+│   │   ├── Hero.tsx
+│   │   ├── CurrencyConverter.tsx
+│   │   ├── TransferSteps.tsx
+│   │   ├── common/         # Shared UI (Header)
+│   │   └── ui/             # shadcn-derived primitives
+│   ├── providers/          # React Query, Redux, Apollo, theme providers
+│   ├── hooks/              # Domain hooks (useAuth, useTransfers)
+│   ├── store/              # Redux Toolkit slices & typed hooks
+│   ├── services/           # REST/GraphQL clients & MSW mocks
+│   ├── constants/          # App constants, endpoints, GraphQL documents
+│   └── types/              # TypeScript interfaces shared across domains
+└── vite.config.ts          # Vite configuration
+```
+
+## Getting Started
+1. **Install dependencies**
+   ```bash
+   npm install
+   ```
+2. **Start the development server**
+   ```bash
+   npm run dev
+   ```
+   - Opens the app with hot module reloading.
+   - [MSW](https://mswjs.io/) mocks are automatically registered (see `src/services/api/mocks`).
+3. **Build for production**
+   ```bash
+   npm run build
+   ```
+4. **Preview the production build**
+   ```bash
+   npm run preview
+   ```
+
+## Quality & Tooling
+- **Linting:** `npm run lint`
+- **Type checking:** TypeScript runs during build; enable your editor's TS/ESLint integrations for the best DX.
+- **React Query Devtools:** Enabled in development via `AppProviders` for inspecting cached queries/mutations.
+
+## Data Layer & API Mocking
+- REST requests are centralized in `src/services/api/restClient.ts` and GraphQL in `src/services/api/graphqlClient.ts`.
+- Domain services (e.g., `transferService`, `authService`) expose typed methods used by Redux thunks and React Query hooks.
+- During local development, MSW (`src/services/api/mocks`) intercepts network calls, returning mock auth, transfer, recipient, and exchange-rate data so the UI functions without a live backend.
+- Swap out or extend mocks when integrating real APIs.
+
+## Customization Tips
+- Update supported currencies in `src/constants/index.ts`.
+- Extend Redux slices or add new ones under `src/store/slices` for additional domains (e.g., beneficiaries, transaction history).
+- Reuse shadcn/ui primitives from `src/components/ui` to keep styling consistent.
+- Theme settings (default theme, system preference) are configured in `AppProviders` via `next-themes`.
+
+## License
+This project is provided as-is for demonstration purposes. Integrate with your organization's licensing requirements as needed.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Routes, Route } from "react-router-dom";
+import AppLayout from "./components/layout/AppLayout";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
 
@@ -10,9 +11,11 @@ const App = () => (
     <Toaster />
     <Sonner />
     <Routes>
-      <Route path="/" element={<Index />} />
-      {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-      <Route path="*" element={<NotFound />} />
+      <Route element={<AppLayout />}>
+        <Route path="/" element={<Index />} />
+        {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+        <Route path="*" element={<NotFound />} />
+      </Route>
     </Routes>
   </TooltipProvider>
 );

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,58 +1,61 @@
 import { ArrowRight, Globe } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Header } from "@/components/common/Header";
 import heroImage from "@/assets/hero-bg.jpg";
 
 export const Hero = () => {
   return (
-    <section 
-      className="relative overflow-hidden py-8 lg:py-12 bg-cover bg-center bg-no-repeat"
-      style={{ backgroundImage: `linear-gradient(rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.95)), url(${heroImage})` }}
+    <section
+      className="relative overflow-hidden bg-cover bg-center bg-no-repeat"
+      style={{
+        backgroundImage: `linear-gradient(rgba(255, 255, 255, 0.92), rgba(255, 255, 255, 0.9)), url(${heroImage})`,
+      }}
     >
-      <Header />
-      <div className="container mx-auto px-2 pt-12">
-        <div className="max-w-4xl mx-auto text-center">
-          <div className="mb-2 inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-1 text-sm font-medium text-primary">
+      <div className="container mx-auto px-4 py-16 sm:py-20 lg:py-28">
+        <div className="mx-auto max-w-4xl rounded-3xl border border-border/40 bg-background/80 p-8 text-center shadow-xl backdrop-blur-sm sm:p-10 lg:p-14">
+          <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/10 px-4 py-1.5 text-sm font-medium uppercase tracking-wider text-primary">
             <Globe className="h-4 w-4" />
             Send money worldwide
           </div>
-          
-          <h1 className="mb-2 text-4xl font-bold tracking-tight lg:text-5xl">
+
+          <h1 className="mb-4 text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
             Fast, secure money transfers
-            <span className="block text-primary">at the best rates</span>
+            <span className="mt-1 block text-primary">at the best rates</span>
           </h1>
-          
-          <p className="mb-3 text-lg text-muted-foreground max-w-2xl mx-auto">
-            Send money to over 200 countries and territories with our award-winning service. 
-            Save up to 90% on transfer fees compared to traditional banks.
+
+          <p className="mx-auto mb-6 max-w-2xl text-base text-muted-foreground sm:text-lg">
+            Send money to over 200 countries and territories with our award-winning service. Save up to 90% on transfer fees compared to traditional banks.
           </p>
-          
-          <div className="flex flex-col sm:flex-row gap-2 justify-center">
-            <Button size="lg" variant="gradient">
+
+          <div className="flex flex-col justify-center gap-3 sm:flex-row">
+            <Button size="lg" variant="gradient" className="h-12 rounded-full px-8 text-base shadow-lg shadow-primary/30">
               Start transfer
               <ArrowRight className="ml-2 h-4 w-4" />
             </Button>
-            <Button variant="outline" size="lg" className="bg-card hover:shadow-card transition-all duration-300">
+            <Button
+              variant="outline"
+              size="lg"
+              className="h-12 rounded-full border-border/60 bg-card/80 px-8 text-base transition-all duration-300 hover:shadow-md"
+            >
               View rates
             </Button>
           </div>
-          
-          <div className="mt-4 grid grid-cols-2 lg:grid-cols-4 gap-2 text-center">
-            <div>
-              <div className="text-xl font-bold text-primary">200+</div>
-              <div className="text-xs text-muted-foreground">Countries</div>
+
+          <div className="mt-8 grid grid-cols-2 gap-3 text-center sm:gap-4 lg:grid-cols-4">
+            <div className="rounded-2xl border border-border/40 bg-card/70 p-4 shadow-sm">
+              <div className="text-2xl font-bold text-primary">200+</div>
+              <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Countries</div>
             </div>
-            <div>
-              <div className="text-xl font-bold text-primary">15M+</div>
-              <div className="text-xs text-muted-foreground">Customers</div>
+            <div className="rounded-2xl border border-border/40 bg-card/70 p-4 shadow-sm">
+              <div className="text-2xl font-bold text-primary">15M+</div>
+              <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Customers</div>
             </div>
-            <div>
-              <div className="text-xl font-bold text-primary">$50B+</div>
-              <div className="text-xs text-muted-foreground">Transferred</div>
+            <div className="rounded-2xl border border-border/40 bg-card/70 p-4 shadow-sm">
+              <div className="text-2xl font-bold text-primary">$50B+</div>
+              <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Transferred</div>
             </div>
-            <div>
-              <div className="text-xl font-bold text-primary">4.8★</div>
-              <div className="text-xs text-muted-foreground">App Rating</div>
+            <div className="rounded-2xl border border-border/40 bg-card/70 p-4 shadow-sm">
+              <div className="text-2xl font-bold text-primary">4.8★</div>
+              <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">App Rating</div>
             </div>
           </div>
         </div>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import { Sun, Moon, LogIn, UserPlus, Building2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useTheme } from "next-themes";
@@ -9,53 +10,70 @@ export const Header = () => {
   const { isAuthenticated, user, logout } = useAuth();
 
   return (
-    <header className="absolute top-0 left-0 right-0 z-10 flex items-center justify-between p-4">
-      {/* Logo */}
-      <div className="flex items-center gap-3">
-        <div className="flex items-center justify-center w-10 h-10 bg-primary/10 rounded-lg">
-          <Building2 className="h-6 w-6 text-primary" />
-        </div>
-        <span className="text-xl font-bold text-foreground">{APP_NAME}</span>
-      </div>
-
-      {/* Auth and Theme Controls */}
-      <div className="flex items-center gap-2">
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
-          className="h-8 w-8 p-0"
+    <header className="sticky top-0 z-50 border-b border-border/60 bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+      <div className="mx-auto flex h-16 w-full max-w-6xl items-center justify-between px-4 sm:px-6 lg:px-8">
+        <Link
+          to="/"
+          className="group flex items-center gap-3 rounded-full px-2 py-1 transition-colors hover:bg-primary/10"
+          aria-label={`${APP_NAME} home`}
         >
-          <Sun className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-          <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
-        </Button>
-        
-        {isAuthenticated ? (
-          <div className="flex items-center gap-2">
-            <span className="text-sm text-muted-foreground">
-              Welcome, {user?.name}
-            </span>
-            <Button 
-              variant="ghost" 
-              size="sm" 
-              onClick={() => logout()}
-              className="h-8 px-2 text-sm"
-            >
-              Logout
-            </Button>
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl border border-primary/30 bg-primary/10 shadow-inner">
+            <Building2 className="h-6 w-6 text-primary transition-transform duration-300 group-hover:scale-110" />
           </div>
-        ) : (
-          <>
-            <Button variant="ghost" size="sm" className="h-8 px-2 text-sm">
-              <LogIn className="h-4 w-4 mr-1" />
-              Sign In
-            </Button>
-            <Button variant="outline" size="sm" className="h-8 px-2 text-sm">
-              <UserPlus className="h-4 w-4 mr-1" />
-              Sign Up
-            </Button>
-          </>
-        )}
+          <div className="flex flex-col leading-tight">
+            <span className="text-base font-semibold tracking-tight text-foreground">{APP_NAME}</span>
+            <span className="text-xs text-muted-foreground">Global transfers, simplified</span>
+          </div>
+        </Link>
+
+        <div className="flex items-center gap-3">
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+            className="relative rounded-full border-border/60 bg-background/80 shadow-sm transition-colors hover:border-primary/50 hover:bg-primary/5"
+            aria-label="Toggle theme"
+          >
+            <Sun className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+            <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+          </Button>
+
+          {isAuthenticated ? (
+            <div className="flex items-center gap-3 rounded-full border border-border/60 bg-card/80 px-3 py-1.5 shadow-sm backdrop-blur">
+              <div className="hidden text-right sm:block">
+                <span className="block text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Welcome</span>
+                <span className="block text-sm font-semibold text-foreground">{user?.name}</span>
+              </div>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => logout()}
+                className="h-8 rounded-full px-4 text-xs font-semibold uppercase tracking-wide hover:bg-primary/10"
+              >
+                Logout
+              </Button>
+            </div>
+          ) : (
+            <div className="flex items-center gap-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-9 rounded-full px-4 text-sm font-medium transition-colors hover:bg-primary/10"
+              >
+                <LogIn className="mr-2 h-4 w-4" />
+                Sign In
+              </Button>
+              <Button
+                variant="gradient"
+                size="sm"
+                className="h-9 rounded-full px-4 text-sm font-semibold shadow-lg shadow-primary/20"
+              >
+                <UserPlus className="mr-2 h-4 w-4" />
+                Sign Up
+              </Button>
+            </div>
+          )}
+        </div>
       </div>
     </header>
   );

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,0 +1,16 @@
+import { Outlet } from "react-router-dom";
+
+import { Header } from "@/components/common/Header";
+
+const AppLayout = () => {
+  return (
+    <div className="flex min-h-screen flex-col bg-background text-foreground">
+      <Header />
+      <main className="flex-1">
+        <Outlet />
+      </main>
+    </div>
+  );
+};
+
+export default AppLayout;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -4,7 +4,7 @@ import { TransferSteps } from "@/components/TransferSteps";
 
 const Index = () => {
   return (
-    <div className="min-h-screen">
+    <div className="space-y-16 pb-16">
       <Hero />
       <CurrencyConverter />
       <TransferSteps />


### PR DESCRIPTION
## Summary
- introduce an application layout that centralizes the shared header and outlet routing
- restyle the sticky header with improved spacing, theme toggle, and auth actions for a cleaner experience
- refresh the hero section and landing page spacing to align with the new shell

## Testing
- `npm run lint` *(fails: existing lint errors in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68d3c46bf6ac8324b7d3ae4148207290