### PR TITLE
Enable live API auth flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ A Vite + React + TypeScript single-page application that showcases a global mone
    npm run dev
    ```
    - Opens the app with hot module reloading.
-   - [MSW](https://mswjs.io/) mocks are automatically registered (see `src/services/api/mocks`).
+   - [MSW](https://mswjs.io/) mocks are automatically registered (see `src/services/api/mocks`). Set `VITE_ENABLE_API_MOCKS=false` in a `.env` file to disable mocks and forward requests to a live backend.
 3. **Build for production**
    ```bash
    npm run build
@@ -71,7 +71,7 @@ A Vite + React + TypeScript single-page application that showcases a global mone
 - REST requests are centralized in `src/services/api/restClient.ts` and GraphQL in `src/services/api/graphqlClient.ts`.
 - Domain services (e.g., `transferService`, `authService`) expose typed methods used by Redux thunks and React Query hooks.
 - During local development, MSW (`src/services/api/mocks`) intercepts network calls, returning mock auth, transfer, recipient, and exchange-rate data so the UI functions without a live backend.
-- Swap out or extend mocks when integrating real APIs.
+- Swap out or extend mocks when integrating real APIs. Configure `VITE_API_BASE_URL` to point to your backend and set `VITE_ENABLE_API_MOCKS=false` to bypass the mock service worker.
 
 ## Customization Tips
 - Update supported currencies in `src/constants/index.ts`.

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,8 +5,11 @@ import App from './App.tsx';
 import { AppProviders } from './providers/AppProviders';
 import './index.css';
 
-// Start MSW in development
-if (import.meta.env.DEV) {
+// Start MSW in development when enabled
+const shouldEnableMocks =
+  import.meta.env.DEV && import.meta.env.VITE_ENABLE_API_MOCKS !== 'false';
+
+if (shouldEnableMocks) {
   import('./services/api/mocks/browser').then(({ worker }) => {
     worker.start({
       onUnhandledRequest: 'bypass',

--- a/src/services/api/restClient.ts
+++ b/src/services/api/restClient.ts
@@ -1,18 +1,65 @@
 import { ApiResponse } from '@/types';
 
+const DEFAULT_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? '/api';
+
 class RestClient {
   private baseURL: string;
 
-  constructor(baseURL: string = '/api') {
+  constructor(baseURL: string = DEFAULT_BASE_URL) {
     this.baseURL = baseURL;
+  }
+
+  setBaseURL(baseURL: string) {
+    this.baseURL = baseURL;
+  }
+
+  getBaseURL() {
+    return this.baseURL;
+  }
+
+  private normalizeResponse<T>(raw: unknown): ApiResponse<T> {
+    if (raw && typeof raw === 'object') {
+      const candidate = raw as Record<string, unknown>;
+
+      if ('data' in candidate && 'success' in candidate) {
+        const { data, success, message } = candidate as ApiResponse<T>;
+        return {
+          data,
+          success,
+          message: message ?? '',
+        };
+      }
+
+      if ('data' in candidate) {
+        return {
+          data: candidate.data as T,
+          success: true,
+          message: typeof candidate.message === 'string' ? candidate.message : '',
+        };
+      }
+
+      if ('success' in candidate) {
+        return {
+          data: candidate.result as T,
+          success: Boolean(candidate.success),
+          message: typeof candidate.message === 'string' ? candidate.message : '',
+        };
+      }
+    }
+
+    return {
+      data: raw as T,
+      success: true,
+      message: '',
+    };
   }
 
   private async request<T>(
     endpoint: string,
     options: RequestInit = {}
   ): Promise<ApiResponse<T>> {
-    const url = `${this.baseURL}${endpoint}`;
-    
+    const url = endpoint.startsWith('http') ? endpoint : `${this.baseURL}${endpoint}`;
+
     const config: RequestInit = {
       headers: {
         'Content-Type': 'application/json',
@@ -22,7 +69,7 @@ class RestClient {
     };
 
     // Add auth token if available
-    const token = localStorage.getItem('auth_token');
+    const token = typeof window !== 'undefined' ? localStorage.getItem('auth_token') : null;
     if (token) {
       config.headers = {
         ...config.headers,
@@ -32,13 +79,31 @@ class RestClient {
 
     try {
       const response = await fetch(url, config);
-      
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
+      const contentType = response.headers.get('content-type');
+      let parsedBody: unknown = null;
+
+      if (contentType && contentType.includes('application/json')) {
+        parsedBody = await response.json();
+      } else {
+        const text = await response.text();
+        if (text) {
+          try {
+            parsedBody = JSON.parse(text) as unknown;
+          } catch {
+            parsedBody = text;
+          }
+        }
       }
 
-      const data = await response.json();
-      return data;
+      if (!response.ok) {
+        const message =
+          (parsedBody && typeof parsedBody === 'object' && 'message' in parsedBody
+            ? String((parsedBody as Record<string, unknown>).message)
+            : response.statusText) || `HTTP error! status: ${response.status}`;
+        throw new Error(message);
+      }
+
+      return this.normalizeResponse<T>(parsedBody);
     } catch (error) {
       console.error('REST API Error:', error);
       throw error;
@@ -49,14 +114,14 @@ class RestClient {
     return this.request<T>(endpoint, { method: 'GET' });
   }
 
-  async post<T>(endpoint: string, data: any): Promise<ApiResponse<T>> {
+  async post<T>(endpoint: string, data: unknown): Promise<ApiResponse<T>> {
     return this.request<T>(endpoint, {
       method: 'POST',
       body: JSON.stringify(data),
     });
   }
 
-  async put<T>(endpoint: string, data: any): Promise<ApiResponse<T>> {
+  async put<T>(endpoint: string, data: unknown): Promise<ApiResponse<T>> {
     return this.request<T>(endpoint, {
       method: 'PUT',
       body: JSON.stringify(data),

--- a/src/store/slices/transferSlice.ts
+++ b/src/store/slices/transferSlice.ts
@@ -2,6 +2,18 @@ import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
 import { TransferState, Transfer, TransferRequest, ExchangeRate } from '@/types';
 import { transferService } from '@/services/transferService';
 
+const getErrorMessage = (error: unknown, fallback: string) => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  return fallback;
+};
+
 const initialState: TransferState = {
   transfers: [],
   currentTransfer: null,
@@ -17,9 +29,12 @@ export const fetchTransfers = createAsyncThunk(
   async (_, { rejectWithValue }) => {
     try {
       const response = await transferService.getTransfers();
+      if (!response.success) {
+        throw new Error(response.message || 'Unable to load transfers');
+      }
       return response.data;
-    } catch (error: any) {
-      return rejectWithValue(error.message);
+    } catch (error: unknown) {
+      return rejectWithValue(getErrorMessage(error, 'Unable to load transfers'));
     }
   }
 );
@@ -29,9 +44,12 @@ export const createTransfer = createAsyncThunk(
   async (transferData: TransferRequest, { rejectWithValue }) => {
     try {
       const response = await transferService.createTransfer(transferData);
+      if (!response.success) {
+        throw new Error(response.message || 'Unable to create transfer');
+      }
       return response.data;
-    } catch (error: any) {
-      return rejectWithValue(error.message);
+    } catch (error: unknown) {
+      return rejectWithValue(getErrorMessage(error, 'Unable to create transfer'));
     }
   }
 );
@@ -41,9 +59,12 @@ export const fetchExchangeRate = createAsyncThunk(
   async ({ from, to }: { from: string; to: string }, { rejectWithValue }) => {
     try {
       const response = await transferService.getExchangeRate(from, to);
+      if (!response.success) {
+        throw new Error(response.message || 'Unable to fetch exchange rate');
+      }
       return { key: `${from}-${to}`, rate: response.data };
-    } catch (error: any) {
-      return rejectWithValue(error.message);
+    } catch (error: unknown) {
+      return rejectWithValue(getErrorMessage(error, 'Unable to fetch exchange rate'));
     }
   }
 );
@@ -53,9 +74,12 @@ export const fetchRecipients = createAsyncThunk(
   async (_, { rejectWithValue }) => {
     try {
       const response = await transferService.getRecipients();
+      if (!response.success) {
+        throw new Error(response.message || 'Unable to load recipients');
+      }
       return response.data;
-    } catch (error: any) {
-      return rejectWithValue(error.message);
+    } catch (error: unknown) {
+      return rejectWithValue(getErrorMessage(error, 'Unable to load recipients'));
     }
   }
 );


### PR DESCRIPTION
## Summary
- allow configuring the REST client base URL and normalize API responses for real backend integration
- harden auth and transfer slices to surface server errors and clear auth tokens on failed lookups
- add an environment toggle to disable MSW mocks and document the new configuration options

## Testing
- npm run build
- npm run lint *(fails: existing lint errors in unrelated UI files)*

------
https://chatgpt.com/codex/tasks/task_e_68d4aa9cece88324b1939672302d4476