### PR TITLE
Add authentication flow and gate transfer actions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { Routes, Route } from "react-router-dom";
 import AppLayout from "./components/layout/AppLayout";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
+import Auth from "./pages/Auth";
 
 const App = () => (
   <TooltipProvider>
@@ -13,6 +14,7 @@ const App = () => (
     <Routes>
       <Route element={<AppLayout />}>
         <Route path="/" element={<Index />} />
+        <Route path="/auth" element={<Auth />} />
         {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
         <Route path="*" element={<NotFound />} />
       </Route>

--- a/src/components/CurrencyConverter.tsx
+++ b/src/components/CurrencyConverter.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { ArrowUpDown, Calculator } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -6,13 +6,15 @@ import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useTransfers } from "@/hooks/useTransfers";
 import { CURRENCIES, FEE_RATES } from "@/constants";
+import { useAuth } from "@/hooks/useAuth";
 
 export const CurrencyConverter = () => {
   const [sendAmount, setSendAmount] = useState("1000");
   const [fromCurrency, setFromCurrency] = useState("USD");
   const [toCurrency, setToCurrency] = useState("EUR");
-  
+
   const { useExchangeRate, createTransfer, isCreatingTransfer } = useTransfers();
+  const { isAuthenticated } = useAuth();
   
   // Get exchange rate from API
   const { data: exchangeRateData, isLoading: isLoadingRate } = useExchangeRate(fromCurrency, toCurrency);
@@ -151,10 +153,19 @@ export const CurrencyConverter = () => {
                 variant="gradient"
                 className="w-full h-9"
                 onClick={handleStartTransfer}
-                disabled={isCreatingTransfer || numSendAmount <= 0}
+                disabled={!isAuthenticated || isCreatingTransfer || numSendAmount <= 0}
               >
-                {isCreatingTransfer ? "Creating..." : "Start transfer"}
+                {isAuthenticated
+                  ? isCreatingTransfer
+                    ? "Creating..."
+                    : "Start transfer"
+                  : "Log in to start"}
               </Button>
+              {!isAuthenticated ? (
+                <p className="text-[11px] text-muted-foreground text-center">
+                  Sign in or create an account to begin a transfer.
+                </p>
+              ) : null}
             </CardContent>
           </Card>
         </div>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -3,7 +3,9 @@ import { Button } from "@/components/ui/button";
 import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from "@/components/ui/carousel";
 import { useEffect, useRef, useState } from "react";
 import Autoplay from "embla-carousel-autoplay";
+import type { EmblaCarouselType } from "embla-carousel";
 import heroImage from "@/assets/hero-bg.jpg";
+import { useNavigate } from "react-router-dom";
 
 const promotionalOffers = [
   {
@@ -21,11 +23,12 @@ const promotionalOffers = [
 ];
 
 export const Hero = () => {
-  const [api, setApi] = useState<any>();
+  const [api, setApi] = useState<EmblaCarouselType>();
   const [current, setCurrent] = useState(0);
   const autoplayRef = useRef(
     Autoplay({ delay: 3000, stopOnInteraction: true, stopOnMouseEnter: true })
   );
+  const navigate = useNavigate();
 
   useEffect(() => {
     if (!api) return;
@@ -103,7 +106,12 @@ export const Hero = () => {
           </div>
 
           <div className="flex justify-center">
-            <Button size="default" variant="gradient" className="h-10 rounded-full px-6 text-sm font-medium shadow-lg shadow-primary/30">
+            <Button
+              size="default"
+              variant="gradient"
+              className="h-10 rounded-full px-6 text-sm font-medium shadow-lg shadow-primary/30"
+              onClick={() => navigate({ pathname: "/auth", search: "?mode=login" })}
+            >
               Start transfer
               <ArrowRight className="ml-1.5 h-3.5 w-3.5" />
             </Button>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { Sun, Moon, LogIn, UserPlus, Building2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useTheme } from "next-themes";
@@ -8,6 +8,11 @@ import { APP_NAME } from "@/constants";
 export const Header = () => {
   const { theme, setTheme } = useTheme();
   const { isAuthenticated, user, logout } = useAuth();
+  const navigate = useNavigate();
+
+  const handleAuthNavigation = (mode: "login" | "register") => {
+    navigate({ pathname: "/auth", search: `?mode=${mode}` });
+  };
 
   return (
     <header className="sticky top-0 z-50 border-b border-border/60 bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60">
@@ -59,6 +64,7 @@ export const Header = () => {
                 variant="ghost"
                 size="sm"
                 className="h-8 rounded-full px-3 text-xs font-medium transition-colors hover:bg-primary/10"
+                onClick={() => handleAuthNavigation("login")}
               >
                 <LogIn className="mr-1.5 h-3.5 w-3.5" />
                 Sign In
@@ -67,6 +73,7 @@ export const Header = () => {
                 variant="gradient"
                 size="sm"
                 className="h-8 rounded-full px-3 text-xs font-medium shadow-lg shadow-primary/20"
+                onClick={() => handleAuthNavigation("register")}
               >
                 <UserPlus className="mr-1.5 h-3.5 w-3.5" />
                 Sign Up

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,6 +1,13 @@
+import { useCallback } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useAppDispatch, useAppSelector } from '@/store';
-import { loginUser, registerUser, logoutUser, getCurrentUser } from '@/store/slices/authSlice';
+import {
+  loginUser,
+  registerUser,
+  logoutUser,
+  getCurrentUser,
+  clearError,
+} from '@/store/slices/authSlice';
 import { LoginCredentials, RegisterCredentials } from '@/types';
 
 export const useAuth = () => {
@@ -40,6 +47,10 @@ export const useAuth = () => {
     },
   });
 
+  const handleClearError = useCallback(() => {
+    dispatch(clearError());
+  }, [dispatch]);
+
   return {
     // State
     user: authState.user,
@@ -51,6 +62,7 @@ export const useAuth = () => {
     login: loginMutation.mutate,
     register: registerMutation.mutate,
     logout: logoutMutation.mutate,
+    clearError: handleClearError,
 
     // Mutation states
     isLoggingIn: loginMutation.isPending,

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -1,0 +1,173 @@
+import { FormEvent, useEffect, useMemo, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { useAuth } from "@/hooks/useAuth";
+import { APP_NAME } from "@/constants";
+
+const Auth = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const [formValues, setFormValues] = useState({ name: "", email: "", password: "" });
+
+  const {
+    login,
+    register: registerUser,
+    isLoggingIn,
+    isRegistering,
+    isAuthenticated,
+    error,
+    clearError,
+  } = useAuth();
+
+  const mode = searchParams.get("mode") === "register" ? "register" : "login";
+  const isRegisterMode = mode === "register";
+  const isSubmitting = isRegisterMode ? isRegistering : isLoggingIn;
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      navigate("/", { replace: true });
+    }
+  }, [isAuthenticated, navigate]);
+
+  useEffect(() => {
+    return () => {
+      clearError();
+    };
+  }, [clearError]);
+
+  const handleModeChange = (nextMode: "login" | "register") => {
+    if (nextMode === mode) {
+      return;
+    }
+
+    const params = new URLSearchParams(searchParams);
+    params.set("mode", nextMode);
+    setSearchParams(params, { replace: true });
+    setFormValues((prev) => ({ ...prev, password: "" }));
+    clearError();
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (isRegisterMode) {
+      registerUser({
+        name: formValues.name.trim(),
+        email: formValues.email.trim(),
+        password: formValues.password,
+      });
+      return;
+    }
+
+    login({
+      email: formValues.email.trim(),
+      password: formValues.password,
+    });
+  };
+
+  const heading = useMemo(
+    () => (isRegisterMode ? "Create your account" : "Welcome back"),
+    [isRegisterMode]
+  );
+
+  const description = useMemo(
+    () =>
+      isRegisterMode
+        ? `Join ${APP_NAME} to send money worldwide in minutes.`
+        : "Sign in to manage transfers and recipients.",
+    [isRegisterMode]
+  );
+
+  return (
+    <section className="flex min-h-[calc(100vh-56px)] items-center justify-center bg-muted/20 px-4 py-12">
+      <Card className="w-full max-w-md shadow-lg">
+        <CardHeader className="space-y-2 text-center">
+          <CardTitle className="text-2xl font-semibold">{heading}</CardTitle>
+          <CardDescription>{description}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="mb-4 flex justify-center gap-2">
+            <Button
+              type="button"
+              variant={isRegisterMode ? "outline" : "gradient"}
+              size="sm"
+              onClick={() => handleModeChange("login")}
+              disabled={isSubmitting}
+            >
+              Sign In
+            </Button>
+            <Button
+              type="button"
+              variant={isRegisterMode ? "gradient" : "outline"}
+              size="sm"
+              onClick={() => handleModeChange("register")}
+              disabled={isSubmitting}
+            >
+              Sign Up
+            </Button>
+          </div>
+
+          {error ? (
+            <Alert variant="destructive" className="mb-4">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          ) : null}
+
+          <form className="space-y-4" onSubmit={handleSubmit}>
+            {isRegisterMode ? (
+              <div className="space-y-2">
+                <Label htmlFor="name">Full name</Label>
+                <Input
+                  id="name"
+                  placeholder="Jane Doe"
+                  value={formValues.name}
+                  onChange={(event) => setFormValues((prev) => ({ ...prev, name: event.target.value }))}
+                  disabled={isSubmitting}
+                  required
+                />
+              </div>
+            ) : null}
+
+            <div className="space-y-2">
+              <Label htmlFor="email">Email address</Label>
+              <Input
+                id="email"
+                type="email"
+                placeholder="you@example.com"
+                value={formValues.email}
+                onChange={(event) => setFormValues((prev) => ({ ...prev, email: event.target.value }))}
+                disabled={isSubmitting}
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="password">Password</Label>
+              <Input
+                id="password"
+                type="password"
+                placeholder="Enter your password"
+                value={formValues.password}
+                onChange={(event) => setFormValues((prev) => ({ ...prev, password: event.target.value }))}
+                disabled={isSubmitting}
+                minLength={6}
+                required
+              />
+            </div>
+
+            <Button type="submit" className="w-full" variant="gradient" disabled={isSubmitting}>
+              {isSubmitting ? "Please wait..." : isRegisterMode ? "Create account" : "Sign in"}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </section>
+  );
+};
+
+export default Auth;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,11 +1,14 @@
 import { Hero } from "@/components/Hero";
 import { CurrencyConverter } from "@/components/CurrencyConverter";
 import { TransferSteps } from "@/components/TransferSteps";
+import { useAuth } from "@/hooks/useAuth";
 
 const Index = () => {
+  const { isAuthenticated } = useAuth();
+
   return (
     <div className="space-y-8 pb-8">
-      <Hero />
+      {!isAuthenticated ? <Hero /> : null}
       <CurrencyConverter />
       <TransferSteps />
     </div>


### PR DESCRIPTION
## Summary
- add a dedicated auth page that supports sign in and sign up flows powered by the existing auth hooks
- update the header and hero ctas to deep-link to the auth experience and prevent the hero from showing after login
- require authentication before starting a transfer from the converter and surface helpful guidance to the user

## Testing
- `npm run lint` *(fails: existing lint violations in untouched shared ui files and services)*

------
https://chatgpt.com/codex/tasks/task_e_68d4b086ee648324bcddadb4041e26bf