### PR TITLE
Replace auth page with reusable dialog

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,6 @@ import { Routes, Route } from "react-router-dom";
 import AppLayout from "./components/layout/AppLayout";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
-import Auth from "./pages/Auth";
 
 const App = () => (
   <TooltipProvider>
@@ -14,7 +13,6 @@ const App = () => (
     <Routes>
       <Route element={<AppLayout />}>
         <Route path="/" element={<Index />} />
-        <Route path="/auth" element={<Auth />} />
         {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
         <Route path="*" element={<NotFound />} />
       </Route>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -5,21 +5,21 @@ import { useEffect, useRef, useState } from "react";
 import Autoplay from "embla-carousel-autoplay";
 import type { EmblaCarouselType } from "embla-carousel";
 import heroImage from "@/assets/hero-bg.jpg";
-import { useNavigate } from "react-router-dom";
+import { useAuthDialog } from "@/providers/AuthDialogProvider";
 
 const promotionalOffers = [
   {
     icon: Star,
     title: "New User get exciting rates on your first three transfers",
     description: "New users only",
-    color: "text-yellow-500"
+    color: "text-yellow-500",
   },
   {
     icon: Zap,
     title: "A referral can get you 0 fees for your next 2 transactions",
     description: "referral only",
-    color: "text-blue-500"
-  }
+    color: "text-blue-500",
+  },
 ];
 
 export const Hero = () => {
@@ -28,7 +28,7 @@ export const Hero = () => {
   const autoplayRef = useRef(
     Autoplay({ delay: 3000, stopOnInteraction: true, stopOnMouseEnter: true })
   );
-  const navigate = useNavigate();
+  const { openAuth } = useAuthDialog();
 
   useEffect(() => {
     if (!api) return;
@@ -110,7 +110,7 @@ export const Hero = () => {
               size="default"
               variant="gradient"
               className="h-10 rounded-full px-6 text-sm font-medium shadow-lg shadow-primary/30"
-              onClick={() => navigate({ pathname: "/auth", search: "?mode=login" })}
+              onClick={() => openAuth("login")}
             >
               Start transfer
               <ArrowRight className="ml-1.5 h-3.5 w-3.5" />

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,18 +1,15 @@
-import { Link, useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { Sun, Moon, LogIn, UserPlus, Building2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useTheme } from "next-themes";
 import { useAuth } from "@/hooks/useAuth";
 import { APP_NAME } from "@/constants";
+import { useAuthDialog } from "@/providers/AuthDialogProvider";
 
 export const Header = () => {
   const { theme, setTheme } = useTheme();
   const { isAuthenticated, user, logout } = useAuth();
-  const navigate = useNavigate();
-
-  const handleAuthNavigation = (mode: "login" | "register") => {
-    navigate({ pathname: "/auth", search: `?mode=${mode}` });
-  };
+  const { openAuth } = useAuthDialog();
 
   return (
     <header className="sticky top-0 z-50 border-b border-border/60 bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60">
@@ -64,7 +61,7 @@ export const Header = () => {
                 variant="ghost"
                 size="sm"
                 className="h-8 rounded-full px-3 text-xs font-medium transition-colors hover:bg-primary/10"
-                onClick={() => handleAuthNavigation("login")}
+                onClick={() => openAuth("login")}
               >
                 <LogIn className="mr-1.5 h-3.5 w-3.5" />
                 Sign In
@@ -73,7 +70,7 @@ export const Header = () => {
                 variant="gradient"
                 size="sm"
                 className="h-8 rounded-full px-3 text-xs font-medium shadow-lg shadow-primary/20"
-                onClick={() => handleAuthNavigation("register")}
+                onClick={() => openAuth("register")}
               >
                 <UserPlus className="mr-1.5 h-3.5 w-3.5" />
                 Sign Up

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,15 +1,18 @@
 import { Outlet } from "react-router-dom";
 
 import { Header } from "@/components/common/Header";
+import { AuthDialogProvider } from "@/providers/AuthDialogProvider";
 
 const AppLayout = () => {
   return (
-    <div className="flex min-h-screen flex-col bg-background text-foreground">
-      <Header />
-      <main className="flex-1">
-        <Outlet />
-      </main>
-    </div>
+    <AuthDialogProvider>
+      <div className="flex min-h-screen flex-col bg-background text-foreground">
+        <Header />
+        <main className="flex-1">
+          <Outlet />
+        </main>
+      </div>
+    </AuthDialogProvider>
   );
 };
 

--- a/src/providers/AuthDialogProvider.tsx
+++ b/src/providers/AuthDialogProvider.tsx
@@ -1,0 +1,53 @@
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from "react";
+
+import { AuthDialog, AuthMode } from "@/components/auth/AuthDialog";
+
+interface AuthDialogContextValue {
+  openAuth: (mode?: AuthMode) => void;
+  closeAuth: () => void;
+}
+
+const AuthDialogContext = createContext<AuthDialogContextValue | undefined>(undefined);
+
+interface AuthDialogProviderProps {
+  children: ReactNode;
+}
+
+export const AuthDialogProvider = ({ children }: AuthDialogProviderProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [mode, setMode] = useState<AuthMode>("login");
+
+  const openAuth = useCallback((nextMode: AuthMode = "login") => {
+    setMode(nextMode);
+    setIsOpen(true);
+  }, []);
+
+  const closeAuth = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      openAuth,
+      closeAuth,
+    }),
+    [openAuth, closeAuth]
+  );
+
+  return (
+    <AuthDialogContext.Provider value={value}>
+      {children}
+      <AuthDialog open={isOpen} mode={mode} onOpenChange={setIsOpen} onModeChange={setMode} />
+    </AuthDialogContext.Provider>
+  );
+};
+
+export const useAuthDialog = () => {
+  const context = useContext(AuthDialogContext);
+
+  if (!context) {
+    throw new Error("useAuthDialog must be used within an AuthDialogProvider");
+  }
+
+  return context;
+};


### PR DESCRIPTION
## Summary
- replace the dedicated /auth route with a shared AuthDialog component
- add an AuthDialogProvider so layout children can open the dialog from anywhere
- update the header and hero actions to open the modal instead of navigating to /auth

## Testing
- npm run lint *(fails: existing lint violations in generated UI primitives and services)*

------
https://chatgpt.com/codex/tasks/task_e_68d4cb8eae788324897f5317d278f915