### PR TITLE
Add authenticated dashboard experience

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { Routes, Route } from "react-router-dom";
 import AppLayout from "./components/layout/AppLayout";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
+import Transactions from "./pages/Transactions";
 
 const App = () => (
   <TooltipProvider>
@@ -13,6 +14,7 @@ const App = () => (
     <Routes>
       <Route element={<AppLayout />}>
         <Route path="/" element={<Index />} />
+        <Route path="/transactions" element={<Transactions />} />
         {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
         <Route path="*" element={<NotFound />} />
       </Route>

--- a/src/components/CurrencyConverter.tsx
+++ b/src/components/CurrencyConverter.tsx
@@ -1,44 +1,133 @@
-import { useState } from "react";
-import { ArrowUpDown, Calculator } from "lucide-react";
+import { FormEvent, useMemo, useState } from "react";
+import { ArrowUpDown, Calculator, CheckCircle, Loader2, UserRound } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { useToast } from "@/components/ui/use-toast";
 import { useTransfers } from "@/hooks/useTransfers";
 import { CURRENCIES, FEE_RATES } from "@/constants";
 import { useAuth } from "@/hooks/useAuth";
+import { useAccount } from "@/hooks/useAccount";
+
+const processingSteps = [
+  "Validating transfer details",
+  "Locking in your exchange rate",
+  "Sending to partner network",
+  "Transfer completed",
+];
+
+const recipientDefaults = {
+  name: "",
+  email: "",
+  accountNumber: "",
+  country: "",
+  bankName: "",
+};
+
+type RecipientFormState = typeof recipientDefaults;
 
 export const CurrencyConverter = () => {
   const [sendAmount, setSendAmount] = useState("1000");
   const [fromCurrency, setFromCurrency] = useState("USD");
   const [toCurrency, setToCurrency] = useState("EUR");
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [currentStep, setCurrentStep] = useState(-1);
+  const [recipient, setRecipient] = useState<RecipientFormState>(recipientDefaults);
+  const [transferError, setTransferError] = useState<string | null>(null);
 
-  const { useExchangeRate, createTransfer, isCreatingTransfer } = useTransfers();
+  const { useExchangeRate, createTransfer, updateStatus, refetchTransfers } = useTransfers();
   const { isAuthenticated } = useAuth();
-  
-  // Get exchange rate from API
+  const { refetchLedger, refetchWallet } = useAccount();
+  const { toast } = useToast();
+
   const { data: exchangeRateData, isLoading: isLoadingRate } = useExchangeRate(fromCurrency, toCurrency);
-  const exchangeRate = exchangeRateData?.rate?.rate || 0.85; // Fallback to mock rate
-  
+  const exchangeRate = exchangeRateData?.rate?.rate ?? 0.85;
+
   const numSendAmount = parseFloat(sendAmount) || 0;
-  const receiveAmount = (numSendAmount * exchangeRate).toFixed(2);
-  const fee = (numSendAmount * FEE_RATES.STANDARD).toFixed(2);
-  const totalAmount = (numSendAmount + parseFloat(fee)).toFixed(2);
+  const receiveAmount = useMemo(() => (numSendAmount * exchangeRate).toFixed(2), [numSendAmount, exchangeRate]);
+  const fee = useMemo(() => (numSendAmount * FEE_RATES.STANDARD).toFixed(2), [numSendAmount]);
+  const totalAmount = useMemo(() => (numSendAmount + parseFloat(fee)).toFixed(2), [numSendAmount, fee]);
 
   const handleSwapCurrencies = () => {
     setFromCurrency(toCurrency);
     setToCurrency(fromCurrency);
   };
 
+  const resetDialogState = () => {
+    setRecipient(recipientDefaults);
+    setCurrentStep(-1);
+    setIsProcessing(false);
+    setTransferError(null);
+  };
+
   const handleStartTransfer = () => {
-    if (numSendAmount > 0) {
-      createTransfer({
+    if (!isAuthenticated) {
+      return;
+    }
+
+    resetDialogState();
+    setIsDialogOpen(true);
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (numSendAmount <= 0 || isProcessing) {
+      return;
+    }
+
+    if (!recipient.name || !recipient.email || !recipient.accountNumber || !recipient.country) {
+      setTransferError("Please fill in all required recipient details.");
+      return;
+    }
+
+    setTransferError(null);
+    setIsProcessing(true);
+
+    const recipientId = `rec-${Date.now()}`;
+
+    createTransfer(
+      {
         fromCurrency,
         toCurrency,
         sendAmount: numSendAmount,
-        recipientId: "1", // Mock recipient ID
-      });
-    }
+        recipientId,
+        recipientDetails: recipient,
+      },
+      {
+        onSuccess: (transfer) => {
+          refetchTransfers();
+          const transferId = transfer.id;
+          processingSteps.forEach((_, index) => {
+            setTimeout(() => {
+              setCurrentStep(index);
+              if (index < processingSteps.length - 1) {
+                updateStatus(transferId, 'processing');
+              } else {
+                updateStatus(transferId, 'completed');
+                refetchWallet();
+                refetchLedger();
+                toast({
+                  title: 'Transfer completed',
+                  description: `${recipient.name} will receive ${toCurrency} ${receiveAmount}.`,
+                });
+                setTimeout(() => {
+                  setIsDialogOpen(false);
+                  resetDialogState();
+                }, 1200);
+              }
+            }, index * 1500);
+          });
+        },
+        onError: (error) => {
+          setTransferError(error instanceof Error ? error.message : 'Unable to create transfer.');
+          setIsProcessing(false);
+        },
+      },
+    );
   };
 
   return (
@@ -51,7 +140,7 @@ export const CurrencyConverter = () => {
               Competitive exchange rates, instant calculations
             </p>
           </div>
-          
+
           <Card className="bg-card">
             <CardHeader className="pb-2">
               <CardTitle className="flex items-center gap-1.5 text-base">
@@ -60,7 +149,6 @@ export const CurrencyConverter = () => {
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-2.5">
-              {/* Send Section */}
               <div className="space-y-0.5">
                 <label className="text-xs font-medium">You send</label>
                 <div className="flex gap-1.5">
@@ -89,7 +177,6 @@ export const CurrencyConverter = () => {
                 </div>
               </div>
 
-              {/* Swap Button */}
               <div className="flex justify-center -my-1">
                 <Button
                   variant="outline"
@@ -102,7 +189,6 @@ export const CurrencyConverter = () => {
                 </Button>
               </div>
 
-              {/* Receive Section */}
               <div className="space-y-0.5">
                 <label className="text-xs font-medium">They receive</label>
                 <div className="flex gap-1.5">
@@ -130,7 +216,6 @@ export const CurrencyConverter = () => {
                 </div>
               </div>
 
-              {/* Rate Info */}
               <div className="bg-muted rounded-md p-2 space-y-0.5">
                 <div className="flex justify-between text-xs">
                   <span>Rate:</span>
@@ -148,18 +233,13 @@ export const CurrencyConverter = () => {
                 </div>
               </div>
 
-              {/* CTA Button */}
               <Button
                 variant="gradient"
                 className="w-full h-9"
                 onClick={handleStartTransfer}
-                disabled={!isAuthenticated || isCreatingTransfer || numSendAmount <= 0}
+                disabled={!isAuthenticated || numSendAmount <= 0}
               >
-                {isAuthenticated
-                  ? isCreatingTransfer
-                    ? "Creating..."
-                    : "Start transfer"
-                  : "Log in to start"}
+                {isAuthenticated ? "Send money" : "Log in to start"}
               </Button>
               {!isAuthenticated ? (
                 <p className="text-[11px] text-muted-foreground text-center">
@@ -170,6 +250,136 @@ export const CurrencyConverter = () => {
           </Card>
         </div>
       </div>
+
+      <Dialog
+        open={isDialogOpen}
+        onOpenChange={(open) => {
+          if (!isProcessing) {
+            setIsDialogOpen(open);
+            if (!open) {
+              resetDialogState();
+            }
+          }
+        }}
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2 text-lg">
+              <UserRound className="h-5 w-5 text-primary" />
+              Recipient details
+            </DialogTitle>
+            <DialogDescription className="text-xs text-muted-foreground">
+              Provide who should receive {toCurrency} {receiveAmount}. We'll guide you through the transfer in real time.
+            </DialogDescription>
+          </DialogHeader>
+          <form onSubmit={handleSubmit} className="space-y-3">
+            <div className="space-y-2">
+              <div className="space-y-1">
+                <Label htmlFor="recipient-name" className="text-xs">Recipient name</Label>
+                <Input
+                  id="recipient-name"
+                  required
+                  value={recipient.name}
+                  onChange={(event) => setRecipient((prev) => ({ ...prev, name: event.target.value }))}
+                  placeholder="Who are you sending to?"
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="recipient-email" className="text-xs">Email</Label>
+                <Input
+                  id="recipient-email"
+                  type="email"
+                  required
+                  value={recipient.email}
+                  onChange={(event) => setRecipient((prev) => ({ ...prev, email: event.target.value }))}
+                  placeholder="Contact email"
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="recipient-account" className="text-xs">Account / IBAN</Label>
+                <Input
+                  id="recipient-account"
+                  required
+                  value={recipient.accountNumber}
+                  onChange={(event) => setRecipient((prev) => ({ ...prev, accountNumber: event.target.value }))}
+                  placeholder="Account number"
+                />
+              </div>
+              <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                <div className="space-y-1">
+                  <Label htmlFor="recipient-country" className="text-xs">Country</Label>
+                  <Input
+                    id="recipient-country"
+                    required
+                    value={recipient.country}
+                    onChange={(event) => setRecipient((prev) => ({ ...prev, country: event.target.value }))}
+                    placeholder="Country"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor="recipient-bank" className="text-xs">Bank (optional)</Label>
+                  <Input
+                    id="recipient-bank"
+                    value={recipient.bankName}
+                    onChange={(event) => setRecipient((prev) => ({ ...prev, bankName: event.target.value }))}
+                    placeholder="Bank name"
+                  />
+                </div>
+              </div>
+            </div>
+
+            {transferError ? (
+              <p className="text-xs text-destructive">{transferError}</p>
+            ) : null}
+
+            <DialogFooter className="flex flex-col gap-3">
+              <div className="space-y-2 rounded-md border border-border/60 bg-muted/60 p-3 text-xs">
+                <div className="flex justify-between">
+                  <span>From:</span>
+                  <span className="font-semibold">{fromCurrency} ${sendAmount}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>To:</span>
+                  <span className="font-semibold">{toCurrency} {receiveAmount}</span>
+                </div>
+                <div className="flex justify-between text-muted-foreground">
+                  <span>Fee</span>
+                  <span>${fee}</span>
+                </div>
+              </div>
+
+              {!isProcessing ? (
+                <Button type="submit" variant="gradient" className="w-full">
+                  Confirm &amp; start transfer
+                </Button>
+              ) : (
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2 text-sm font-medium text-primary">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Sending money securely...
+                  </div>
+                  <ul className="space-y-1 text-xs text-muted-foreground">
+                    {processingSteps.map((step, index) => (
+                      <li key={step} className="flex items-center gap-2">
+                        {index < currentStep ? (
+                          <CheckCircle className="h-3.5 w-3.5 text-emerald-500" />
+                        ) : index === currentStep ? (
+                          <Loader2 className="h-3.5 w-3.5 animate-spin text-primary" />
+                        ) : (
+                          <span className="flex h-3.5 w-3.5 items-center justify-center rounded-full border border-border/70 text-[9px]">
+                            {index + 1}
+                          </span>
+                        )}
+                        <span className={index <= currentStep ? "text-foreground" : ""}>{step}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
     </section>
   );
 };

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,15 +1,41 @@
 import { Link } from "react-router-dom";
-import { Sun, Moon, LogIn, UserPlus, Building2 } from "lucide-react";
+import { Sun, Moon, LogIn, UserPlus, Building2, Wallet } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useTheme } from "next-themes";
 import { useAuth } from "@/hooks/useAuth";
 import { APP_NAME } from "@/constants";
 import { useAuthDialog } from "@/providers/AuthDialogProvider";
+import { useAccount } from "@/hooks/useAccount";
+import { Skeleton } from "@/components/ui/skeleton";
 
 export const Header = () => {
   const { theme, setTheme } = useTheme();
   const { isAuthenticated, user, logout } = useAuth();
   const { openAuth } = useAuthDialog();
+  const { wallet, isLoading: isLoadingAccount } = useAccount();
+
+  const renderWalletBadge = () => {
+    if (!wallet && !isLoadingAccount) {
+      return null;
+    }
+
+    return (
+      <div className="hidden items-center gap-1 rounded-full border border-border/60 bg-background/70 px-2 py-1 text-[11px] font-medium text-muted-foreground sm:flex">
+        <Wallet className="h-3 w-3 text-primary" />
+        {wallet ? (
+          <span>
+            {new Intl.NumberFormat("en-US", {
+              style: "currency",
+              currency: wallet.currency,
+              maximumFractionDigits: 2,
+            }).format(wallet.balance)}
+          </span>
+        ) : (
+          <Skeleton className="h-3 w-16" />
+        )}
+      </div>
+    );
+  };
 
   return (
     <header className="sticky top-0 z-50 border-b border-border/60 bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60">
@@ -42,6 +68,7 @@ export const Header = () => {
 
           {isAuthenticated ? (
             <div className="flex items-center gap-2 rounded-full border border-border/60 bg-card/80 px-2.5 py-1 shadow-sm backdrop-blur">
+              {renderWalletBadge()}
               <div className="hidden text-right sm:block">
                 <span className="block text-[10px] font-medium uppercase tracking-wide text-muted-foreground">Welcome</span>
                 <span className="block text-xs font-semibold text-foreground">{user?.name}</span>

--- a/src/components/dashboard/DashboardSidebar.tsx
+++ b/src/components/dashboard/DashboardSidebar.tsx
@@ -1,0 +1,202 @@
+import { Link } from "react-router-dom";
+import { ArrowUpRight, Clock, RefreshCw } from "lucide-react";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuItem,
+  SidebarMenuButton,
+  SidebarProvider,
+  SidebarRail,
+} from "@/components/ui/sidebar";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
+import { useAccount } from "@/hooks/useAccount";
+import { useTransfers } from "@/hooks/useTransfers";
+import { useMemo } from "react";
+
+const formatCurrency = (value: number, currency: string) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+    maximumFractionDigits: 2,
+  }).format(value);
+
+const formatDate = (value: string) =>
+  new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(value));
+
+export const DashboardSidebar = ({ children }: { children: React.ReactNode }) => {
+  const { wallet, ledger, isLoading: isLoadingAccount, refetchLedger, refetchWallet } = useAccount();
+  const { transfers, isLoading: isLoadingTransfers } = useTransfers();
+
+  const latestTransfers = useMemo(() => {
+    if (!Array.isArray(transfers)) return [];
+    return [...transfers].slice(0, 3);
+  }, [transfers]);
+
+  const recentLedger = useMemo(() => {
+    if (!Array.isArray(ledger)) return [];
+    return ledger.slice(0, 5);
+  }, [ledger]);
+
+  return (
+    <SidebarProvider>
+      <Sidebar collapsible="icon" className="bg-muted/40">
+        <SidebarHeader className="space-y-2">
+          <div>
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Wallet</h3>
+            {wallet ? (
+              <p className="text-lg font-semibold text-foreground">
+                {formatCurrency(wallet.balance, wallet.currency)}
+              </p>
+            ) : (
+              <Skeleton className="h-5 w-24" />
+            )}
+            <div className="text-[11px] text-muted-foreground">
+              <span>Ledger balance </span>
+              {wallet ? (
+                <span className="font-semibold text-foreground/80">
+                  {formatCurrency(wallet.ledgerBalance, wallet.currency)}
+                </span>
+              ) : (
+                <Skeleton className="mt-1 h-3 w-16" />
+              )}
+            </div>
+          </div>
+          <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+            <Clock className="h-3 w-3" />
+            <span>
+              Updated {wallet ? formatDate(wallet.lastUpdated) : "soon"}
+            </span>
+          </div>
+          <div className="flex gap-2">
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-7 flex-1 text-[11px]"
+              onClick={() => {
+                refetchWallet();
+                refetchLedger();
+              }}
+            >
+              <RefreshCw className="mr-1 h-3 w-3" />
+              Refresh
+            </Button>
+            {wallet ? (
+              <Badge variant="secondary" className="h-7 rounded-full px-3 text-[11px]">
+                Pending {formatCurrency(wallet.pending, wallet.currency)}
+              </Badge>
+            ) : (
+              <Skeleton className="h-7 w-20 rounded-full" />
+            )}
+          </div>
+        </SidebarHeader>
+        <Separator className="mx-2" />
+        <SidebarContent>
+          <SidebarGroup>
+            <SidebarGroupLabel>Recent ledger</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                {isLoadingAccount && !recentLedger.length ? (
+                  Array.from({ length: 4 }).map((_, index) => (
+                    <SidebarMenuItem key={`ledger-skeleton-${index}`}>
+                      <Skeleton className="h-10 w-full rounded-md" />
+                    </SidebarMenuItem>
+                  ))
+                ) : recentLedger.length ? (
+                  recentLedger.map((entry) => (
+                    <SidebarMenuItem key={entry.id}>
+                      <SidebarMenuButton className="flex-col items-start gap-1">
+                        <div className="flex w-full items-center justify-between text-xs font-semibold">
+                          <span>{entry.description}</span>
+                          <span className={entry.type === 'credit' ? 'text-emerald-500' : 'text-red-500'}>
+                            {entry.type === 'credit' ? '+' : '-'}{formatCurrency(entry.amount, entry.currency)}
+                          </span>
+                        </div>
+                        <span className="text-[11px] text-muted-foreground">{formatDate(entry.createdAt)} • {entry.reference}</span>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                  ))
+                ) : (
+                  <p className="px-2 text-xs text-muted-foreground">No ledger activity yet.</p>
+                )}
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+          <SidebarGroup>
+            <SidebarGroupLabel className="flex items-center justify-between">
+              <span>Latest transfers</span>
+              <Badge variant="outline" className="text-[11px]">
+                {Array.isArray(transfers) ? transfers.length : 0} total
+              </Badge>
+            </SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                {isLoadingTransfers && !latestTransfers.length ? (
+                  Array.from({ length: 3 }).map((_, index) => (
+                    <SidebarMenuItem key={`transfer-skeleton-${index}`}>
+                      <Skeleton className="h-12 w-full rounded-md" />
+                    </SidebarMenuItem>
+                  ))
+                ) : latestTransfers.length ? (
+                  latestTransfers.map((transfer) => (
+                    <SidebarMenuItem key={transfer.id}>
+                      <SidebarMenuButton className="flex-col items-start gap-1">
+                        <div className="flex w-full items-center justify-between text-xs font-semibold">
+                          <span>{transfer.toCurrency} transfer</span>
+                          <Badge
+                            variant={
+                              transfer.status === 'completed'
+                                ? 'secondary'
+                                : transfer.status === 'failed'
+                                ? 'destructive'
+                                : 'outline'
+                            }
+                            className="text-[10px]"
+                          >
+                            {transfer.status}
+                          </Badge>
+                        </div>
+                        <div className="flex w-full items-center justify-between text-[11px] text-muted-foreground">
+                          <span>{transfer.recipientDetails?.name ?? 'Recipient'} • {formatDate(transfer.createdAt)}</span>
+                          <span className="font-medium text-foreground">
+                            {formatCurrency(transfer.totalAmount, transfer.fromCurrency)}
+                          </span>
+                        </div>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                  ))
+                ) : (
+                  <p className="px-2 text-xs text-muted-foreground">No transfers yet. Start one now!</p>
+                )}
+              </SidebarMenu>
+              <Button asChild variant="ghost" size="sm" className="mt-2 h-8 w-full text-xs">
+                <Link to="/transactions" className="flex items-center justify-center gap-1">
+                  View all transfers
+                  <ArrowUpRight className="h-3 w-3" />
+                </Link>
+              </Button>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        </SidebarContent>
+        <SidebarFooter className="text-[11px] text-muted-foreground">
+          <p>Track balances and history from here. Collapse for more space when you need it.</p>
+        </SidebarFooter>
+        <SidebarRail />
+      </Sidebar>
+      {children}
+    </SidebarProvider>
+  );
+};

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ));
 Command.displayName = CommandPrimitive.displayName;
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, ...props }, ref) => {
   return (

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -36,6 +36,10 @@ export const API_ENDPOINTS = {
     GET: (id: string) => `/transfers/${id}`,
     RATES: '/transfers/rates',
   },
+  ACCOUNTS: {
+    WALLET: '/wallet',
+    LEDGER: '/wallet/ledger',
+  },
   RECIPIENTS: {
     LIST: '/recipients',
     CREATE: '/recipients',

--- a/src/hooks/useAccount.ts
+++ b/src/hooks/useAccount.ts
@@ -1,0 +1,33 @@
+import { useQuery } from '@tanstack/react-query';
+import { useAppDispatch, useAppSelector } from '@/store';
+import { fetchLedger, fetchWalletSummary } from '@/store/slices/accountSlice';
+import { useAuth } from './useAuth';
+
+export const useAccount = () => {
+  const dispatch = useAppDispatch();
+  const { isAuthenticated } = useAuth();
+  const accountState = useAppSelector((state) => state.account);
+
+  const walletQuery = useQuery({
+    queryKey: ['walletSummary'],
+    queryFn: () => dispatch(fetchWalletSummary()).unwrap(),
+    enabled: isAuthenticated,
+    staleTime: 60 * 1000,
+  });
+
+  const ledgerQuery = useQuery({
+    queryKey: ['ledgerEntries'],
+    queryFn: () => dispatch(fetchLedger()).unwrap(),
+    enabled: isAuthenticated,
+    staleTime: 60 * 1000,
+  });
+
+  return {
+    wallet: walletQuery.data ?? accountState.wallet,
+    ledger: ledgerQuery.data ?? accountState.ledger,
+    isLoading: accountState.loading || walletQuery.isLoading || ledgerQuery.isLoading,
+    error: accountState.error,
+    refetchWallet: walletQuery.refetch,
+    refetchLedger: ledgerQuery.refetch,
+  };
+};

--- a/src/hooks/useTransfers.ts
+++ b/src/hooks/useTransfers.ts
@@ -1,7 +1,8 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useAppDispatch, useAppSelector } from '@/store';
-import { fetchTransfers, createTransfer, fetchExchangeRate, fetchRecipients } from '@/store/slices/transferSlice';
+import { fetchTransfers, createTransfer, fetchExchangeRate, fetchRecipients, updateTransferStatus } from '@/store/slices/transferSlice';
 import { TransferRequest } from '@/types';
+import { useCallback } from 'react';
 
 export const useTransfers = () => {
   const dispatch = useAppDispatch();
@@ -9,7 +10,7 @@ export const useTransfers = () => {
   const transferState = useAppSelector((state) => state.transfer);
 
   // Fetch transfers query
-  const { data: transfers, isLoading: isLoadingTransfers } = useQuery({
+  const { data: transfers, isLoading: isLoadingTransfers, refetch: refetchTransfers } = useQuery({
     queryKey: ['transfers'],
     queryFn: () => dispatch(fetchTransfers()).unwrap(),
     staleTime: 2 * 60 * 1000, // 2 minutes
@@ -53,6 +54,12 @@ export const useTransfers = () => {
     // Actions
     createTransfer: createTransferMutation.mutate,
     useExchangeRate,
+    updateStatus: useCallback(
+      (transferId: string, status: 'pending' | 'processing' | 'completed' | 'failed') =>
+        dispatch(updateTransferStatus({ id: transferId, status })),
+      [dispatch],
+    ),
+    refetchTransfers,
 
     // Mutation states
     isCreatingTransfer: createTransferMutation.isPending,

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -2,16 +2,52 @@ import { Hero } from "@/components/Hero";
 import { CurrencyConverter } from "@/components/CurrencyConverter";
 import { TransferSteps } from "@/components/TransferSteps";
 import { useAuth } from "@/hooks/useAuth";
+import { DashboardSidebar } from "@/components/dashboard/DashboardSidebar";
+import { SidebarInset, SidebarTrigger } from "@/components/ui/sidebar";
+import { Button } from "@/components/ui/button";
+import { ArrowRight } from "lucide-react";
+import { Link } from "react-router-dom";
 
 const Index = () => {
   const { isAuthenticated } = useAuth();
 
+  if (!isAuthenticated) {
+    return (
+      <div className="space-y-8 pb-8">
+        <Hero />
+        <CurrencyConverter />
+        <TransferSteps />
+      </div>
+    );
+  }
+
   return (
-    <div className="space-y-8 pb-8">
-      {!isAuthenticated ? <Hero /> : null}
-      <CurrencyConverter />
-      <TransferSteps />
-    </div>
+    <DashboardSidebar>
+      <SidebarInset>
+        <div className="flex flex-col gap-6 px-4 py-6 lg:px-8">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-center gap-2">
+              <SidebarTrigger className="md:hidden" />
+              <div>
+                <h1 className="text-xl font-semibold text-foreground">Welcome back</h1>
+                <p className="text-sm text-muted-foreground">
+                  Send money instantly and keep an eye on your balances in one place.
+                </p>
+              </div>
+            </div>
+            <Button asChild variant="outline" size="sm" className="h-9">
+              <Link to="/transactions" className="flex items-center gap-1.5 text-xs">
+                View transfer history
+                <ArrowRight className="h-3.5 w-3.5" />
+              </Link>
+            </Button>
+          </div>
+
+          <CurrencyConverter />
+          <TransferSteps />
+        </div>
+      </SidebarInset>
+    </DashboardSidebar>
   );
 };
 

--- a/src/pages/Transactions.tsx
+++ b/src/pages/Transactions.tsx
@@ -1,0 +1,136 @@
+import { useMemo } from "react";
+import { Link } from "react-router-dom";
+import { ArrowLeft, ArrowUpRight } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { useTransfers } from "@/hooks/useTransfers";
+import { useAccount } from "@/hooks/useAccount";
+
+const statusVariant = {
+  completed: "secondary" as const,
+  processing: "outline" as const,
+  pending: "outline" as const,
+  failed: "destructive" as const,
+};
+
+const formatCurrency = (value: number, currency: string) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+    maximumFractionDigits: 2,
+  }).format(value);
+
+const formatDate = (value: string) =>
+  new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(value));
+
+const Transactions = () => {
+  const { transfers, isLoading } = useTransfers();
+  const { wallet } = useAccount();
+
+  const rows = useMemo(() => (Array.isArray(transfers) ? transfers : []), [transfers]);
+
+  return (
+    <div className="container mx-auto space-y-6 px-4 py-6 lg:px-8">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Button asChild variant="ghost" size="sm" className="h-8 px-2 text-xs">
+              <Link to="/" className="flex items-center gap-1">
+                <ArrowLeft className="h-3.5 w-3.5" />
+                Back to dashboard
+              </Link>
+            </Button>
+            {wallet ? (
+              <Badge variant="secondary" className="rounded-full px-3 text-[11px]">
+                Wallet {formatCurrency(wallet.balance, wallet.currency)}
+              </Badge>
+            ) : null}
+          </div>
+          <h1 className="text-2xl font-semibold text-foreground">Transfer history</h1>
+          <p className="text-sm text-muted-foreground">
+            Review all transfers, their statuses and recipient details. Click any row for a quick overview.
+          </p>
+        </div>
+        <Button asChild variant="gradient" size="sm" className="h-10">
+          <Link to="/" className="flex items-center gap-1.5 text-xs">
+            Start a new transfer
+            <ArrowUpRight className="h-3.5 w-3.5" />
+          </Link>
+        </Button>
+      </div>
+
+      <Card className="border-border/60">
+        <CardHeader className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <CardTitle className="text-base font-semibold">All transfers</CardTitle>
+            <p className="text-xs text-muted-foreground">
+              {isLoading ? "Loading your transfers..." : `${rows.length} transfers recorded`}
+            </p>
+          </div>
+        </CardHeader>
+        <CardContent className="overflow-x-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[160px]">Created</TableHead>
+                <TableHead>Recipient</TableHead>
+                <TableHead>From</TableHead>
+                <TableHead>To</TableHead>
+                <TableHead className="text-right">Total</TableHead>
+                <TableHead>Status</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {isLoading ? (
+                <TableRow>
+                  <TableCell colSpan={6} className="h-24 text-center text-sm text-muted-foreground">
+                    Loading transfers...
+                  </TableCell>
+                </TableRow>
+              ) : rows.length ? (
+                rows.map((transfer) => (
+                  <TableRow key={transfer.id}>
+                    <TableCell className="text-xs text-muted-foreground">{formatDate(transfer.createdAt)}</TableCell>
+                    <TableCell className="text-sm font-medium text-foreground">
+                      <div>{transfer.recipientDetails?.name ?? 'Recipient'}</div>
+                      <div className="text-xs text-muted-foreground">{transfer.recipientDetails?.email}</div>
+                    </TableCell>
+                    <TableCell className="text-xs text-muted-foreground">
+                      {formatCurrency(transfer.sendAmount, transfer.fromCurrency)} {transfer.fromCurrency}
+                    </TableCell>
+                    <TableCell className="text-xs text-muted-foreground">
+                      {formatCurrency(transfer.receiveAmount, transfer.toCurrency)} {transfer.toCurrency}
+                    </TableCell>
+                    <TableCell className="text-right text-sm font-semibold">
+                      {formatCurrency(transfer.totalAmount, transfer.fromCurrency)}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={statusVariant[transfer.status]} className="capitalize">
+                        {transfer.status}
+                      </Badge>
+                    </TableCell>
+                  </TableRow>
+                ))
+              ) : (
+                <TableRow>
+                  <TableCell colSpan={6} className="h-24 text-center text-sm text-muted-foreground">
+                    No transfers yet. Send your first transfer from the dashboard.
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default Transactions;

--- a/src/services/accountService.ts
+++ b/src/services/accountService.ts
@@ -1,0 +1,15 @@
+import { API_ENDPOINTS } from '@/constants';
+import { restClient } from './api/restClient';
+import { ApiResponse, LedgerEntry, WalletSummary } from '@/types';
+
+class AccountService {
+  async getWalletSummary(): Promise<ApiResponse<WalletSummary>> {
+    return restClient.get(API_ENDPOINTS.ACCOUNTS.WALLET);
+  }
+
+  async getLedger(): Promise<ApiResponse<LedgerEntry[]>> {
+    return restClient.get(API_ENDPOINTS.ACCOUNTS.LEDGER);
+  }
+}
+
+export const accountService = new AccountService();

--- a/src/services/transferService.ts
+++ b/src/services/transferService.ts
@@ -23,20 +23,20 @@ class TransferService {
 
   // GraphQL method for exchange rates
   async getExchangeRateGraphQL(from: string, to: string): Promise<ExchangeRate> {
-    const { data } = await graphqlClient.query({
+    const { data } = await graphqlClient.query<{ exchangeRates: ExchangeRate }>({
       query: gql(GRAPHQL_OPERATIONS.GET_EXCHANGE_RATES),
       variables: { from, to },
     });
-    return (data as any).exchangeRates;
+    return data.exchangeRates;
   }
 
   // GraphQL method for creating transfer
   async createTransferGraphQL(transferData: TransferRequest): Promise<Transfer> {
-    const { data } = await graphqlClient.mutate({
+    const { data } = await graphqlClient.mutate<{ createTransfer: Transfer }>({
       mutation: gql(GRAPHQL_OPERATIONS.CREATE_TRANSFER),
       variables: { input: transferData },
     });
-    return (data as any).createTransfer;
+    return data.createTransfer;
   }
 
   async getRecipients(): Promise<ApiResponse<Recipient[]>> {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2,11 +2,13 @@ import { configureStore } from '@reduxjs/toolkit';
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
 import authSlice from './slices/authSlice';
 import transferSlice from './slices/transferSlice';
+import accountSlice from './slices/accountSlice';
 
 export const store = configureStore({
   reducer: {
     auth: authSlice,
     transfer: transferSlice,
+    account: accountSlice,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({

--- a/src/store/slices/accountSlice.ts
+++ b/src/store/slices/accountSlice.ts
@@ -1,0 +1,95 @@
+import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { AccountState, LedgerEntry, WalletSummary } from '@/types';
+import { accountService } from '@/services/accountService';
+
+const initialState: AccountState = {
+  wallet: null,
+  ledger: [],
+  loading: false,
+  error: null,
+};
+
+const getErrorMessage = (error: unknown, fallback: string) => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  return fallback;
+};
+
+export const fetchWalletSummary = createAsyncThunk(
+  'account/fetchWalletSummary',
+  async (_, { rejectWithValue }) => {
+    try {
+      const response = await accountService.getWalletSummary();
+      if (!response.success) {
+        throw new Error(response.message || 'Unable to load wallet');
+      }
+      return response.data;
+    } catch (error: unknown) {
+      return rejectWithValue(getErrorMessage(error, 'Unable to load wallet'));
+    }
+  }
+);
+
+export const fetchLedger = createAsyncThunk(
+  'account/fetchLedger',
+  async (_, { rejectWithValue }) => {
+    try {
+      const response = await accountService.getLedger();
+      if (!response.success) {
+        throw new Error(response.message || 'Unable to load ledger');
+      }
+      return response.data;
+    } catch (error: unknown) {
+      return rejectWithValue(getErrorMessage(error, 'Unable to load ledger'));
+    }
+  }
+);
+
+const accountSlice = createSlice({
+  name: 'account',
+  initialState,
+  reducers: {
+    addLedgerEntry: (state, action: PayloadAction<LedgerEntry>) => {
+      state.ledger = [action.payload, ...state.ledger].slice(0, 12);
+    },
+    setWalletSummary: (state, action: PayloadAction<WalletSummary>) => {
+      state.wallet = action.payload;
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchWalletSummary.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(fetchWalletSummary.fulfilled, (state, action) => {
+        state.loading = false;
+        state.wallet = action.payload as WalletSummary;
+      })
+      .addCase(fetchWalletSummary.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload as string;
+      })
+      .addCase(fetchLedger.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(fetchLedger.fulfilled, (state, action) => {
+        state.loading = false;
+        state.ledger = action.payload as LedgerEntry[];
+      })
+      .addCase(fetchLedger.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload as string;
+      });
+  },
+});
+
+export const { addLedgerEntry, setWalletSummary } = accountSlice.actions;
+export default accountSlice.reducer;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,6 +4,7 @@ export interface User {
   email: string;
   name: string;
   avatar?: string;
+  wallet?: WalletSummary;
 }
 
 // Auth types
@@ -43,6 +44,7 @@ export interface Transfer {
   totalAmount: number;
   status: 'pending' | 'processing' | 'completed' | 'failed';
   recipientId: string;
+  recipientDetails?: TransferRecipient;
   createdAt: string;
   updatedAt: string;
 }
@@ -52,6 +54,7 @@ export interface TransferRequest {
   toCurrency: string;
   sendAmount: number;
   recipientId: string;
+  recipientDetails?: TransferRecipient;
 }
 
 export interface ExchangeRate {
@@ -77,6 +80,39 @@ export interface TransferState {
   currentTransfer: Transfer | null;
   exchangeRates: Record<string, ExchangeRate>;
   recipients: Recipient[];
+  loading: boolean;
+  error: string | null;
+}
+
+export interface WalletSummary {
+  balance: number;
+  currency: string;
+  pending: number;
+  ledgerBalance: number;
+  lastUpdated: string;
+}
+
+export interface LedgerEntry {
+  id: string;
+  type: 'credit' | 'debit';
+  amount: number;
+  currency: string;
+  description: string;
+  reference: string;
+  createdAt: string;
+}
+
+export interface TransferRecipient {
+  name: string;
+  email: string;
+  accountNumber: string;
+  country: string;
+  bankName?: string;
+}
+
+export interface AccountState {
+  wallet: WalletSummary | null;
+  ledger: LedgerEntry[];
   loading: boolean;
   error: string | null;
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animatePlugin from "tailwindcss-animate";
 
 export default {
   darkMode: ["class"],
@@ -98,5 +99,5 @@ export default {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [animatePlugin],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add account state, services, and hooks for wallet and ledger data with updated mock API responses
- create authenticated dashboard layout with collapsible sidebar, header wallet badge, and detailed transactions page
- refresh transfer flow with recipient modal, progress feedback, and supporting type and configuration updates

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4d7a3990883248015abe415104d0b