### PR TITLE
Add dark gradient background for dark theme

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -96,6 +96,7 @@
     --accent-foreground: 222 20% 10%;
     --border: 220 15% 25%;
     --input: 220 15% 20%;
+    --gradient-bg: linear-gradient(180deg, hsl(222 20% 12%), hsl(222 20% 8%));
   }
 }
 


### PR DESCRIPTION
## Summary
- define a dark-friendly value for the `--gradient-bg` CSS variable within the dark theme scope so the global background matches the palette
- confirm the existing body background declaration picks up the new gradient during manual theme toggling

## Testing
- Manual theme toggle in development server

------
https://chatgpt.com/codex/tasks/task_e_68d967b976148324a1b2fcffccb88aae