### PR TITLE
Use semantic tokens on 404 page

### DIFF
--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -9,11 +9,11 @@ const NotFound = () => {
   }, [location.pathname]);
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-100">
+    <div className="flex min-h-screen items-center justify-center bg-background">
       <div className="text-center">
-        <h1 className="mb-4 text-4xl font-bold">404</h1>
-        <p className="mb-4 text-xl text-gray-600">Oops! Page not found</p>
-        <a href="/" className="text-blue-500 underline hover:text-blue-700">
+        <h1 className="mb-4 text-4xl font-bold text-foreground">404</h1>
+        <p className="mb-4 text-xl text-muted-foreground">Oops! Page not found</p>
+        <a href="/" className="text-primary underline hover:text-primary/80">
           Return to Home
         </a>
       </div>


### PR DESCRIPTION
## Summary
- switch the Not Found page wrapper and text colors to use semantic tokens for background and typography
- ensure the return link uses the primary token so it adapts to theme changes

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d967cb405c832497c4e518071c80aa