### PR TITLE
Add delivery method support to transfers

### DIFF
--- a/src/components/CurrencyConverter.tsx
+++ b/src/components/CurrencyConverter.tsx
@@ -11,6 +11,7 @@ import { useTransfers } from "@/hooks/useTransfers";
 import { CURRENCIES, FEE_RATES } from "@/constants";
 import { useAuth } from "@/hooks/useAuth";
 import { useAccount } from "@/hooks/useAccount";
+import { DeliveryMethod } from "@/types";
 
 const processingSteps = [
   "Validating transfer details",
@@ -43,7 +44,7 @@ export const CurrencyConverter = () => {
   const [currentStep, setCurrentStep] = useState(-1);
   const [recipient, setRecipient] = useState<RecipientFormState>(recipientDefaults);
   const [transferError, setTransferError] = useState<string | null>(null);
-  const [transferMethod, setTransferMethod] = useState("bank");
+  const [transferMethod, setTransferMethod] = useState<DeliveryMethod>("bank");
 
   const { useExchangeRate, createTransfer, updateStatus, refetchTransfers } = useTransfers();
   const { isAuthenticated } = useAuth();
@@ -113,6 +114,7 @@ export const CurrencyConverter = () => {
         sendAmount: numSendAmount,
         recipientId,
         recipientDetails: recipient,
+        deliveryMethod: transferMethod,
       },
       {
         onSuccess: (transfer) => {
@@ -147,7 +149,7 @@ export const CurrencyConverter = () => {
     );
   };
 
-  const transferMethods = [
+  const transferMethods: Array<{ id: DeliveryMethod; label: string; icon: typeof Building2; desc: string; fee: string }> = [
     { id: "bank", label: "Bank", icon: Building2, desc: "1-2 days", fee: fee },
     { id: "card", label: "Card", icon: CreditCard, desc: "Instant", fee: (parseFloat(fee) + 2).toFixed(2) },
     { id: "cash", label: "Cash", icon: Banknote, desc: "30 mins", fee: fee }

--- a/src/pages/Transactions.tsx
+++ b/src/pages/Transactions.tsx
@@ -7,6 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { useTransfers } from "@/hooks/useTransfers";
 import { useAccount } from "@/hooks/useAccount";
+import { DeliveryMethod } from "@/types";
 
 const statusVariant = {
   completed: "secondary" as const,
@@ -29,6 +30,12 @@ const formatDate = (value: string) =>
     hour: "numeric",
     minute: "2-digit",
   }).format(new Date(value));
+
+const deliveryMethodLabels: Record<DeliveryMethod, string> = {
+  bank: "Bank transfer",
+  card: "Card payout",
+  cash: "Cash pickup",
+};
 
 const Transactions = () => {
   const { transfers, isLoading } = useTransfers();
@@ -83,6 +90,7 @@ const Transactions = () => {
                 <TableHead>Recipient</TableHead>
                 <TableHead>From</TableHead>
                 <TableHead>To</TableHead>
+                <TableHead>Method</TableHead>
                 <TableHead className="text-right">Total</TableHead>
                 <TableHead>Status</TableHead>
               </TableRow>
@@ -90,7 +98,7 @@ const Transactions = () => {
             <TableBody>
               {isLoading ? (
                 <TableRow>
-                  <TableCell colSpan={6} className="h-24 text-center text-sm text-muted-foreground">
+                  <TableCell colSpan={7} className="h-24 text-center text-sm text-muted-foreground">
                     Loading transfers...
                   </TableCell>
                 </TableRow>
@@ -108,6 +116,11 @@ const Transactions = () => {
                     <TableCell className="text-xs text-muted-foreground">
                       {formatCurrency(transfer.receiveAmount, transfer.toCurrency)} {transfer.toCurrency}
                     </TableCell>
+                    <TableCell className="text-xs text-muted-foreground">
+                      <Badge variant="outline" className="capitalize">
+                        {deliveryMethodLabels[transfer.deliveryMethod] ?? transfer.deliveryMethod}
+                      </Badge>
+                    </TableCell>
                     <TableCell className="text-right text-sm font-semibold">
                       {formatCurrency(transfer.totalAmount, transfer.fromCurrency)}
                     </TableCell>
@@ -120,7 +133,7 @@ const Transactions = () => {
                 ))
               ) : (
                 <TableRow>
-                  <TableCell colSpan={6} className="h-24 text-center text-sm text-muted-foreground">
+                  <TableCell colSpan={7} className="h-24 text-center text-sm text-muted-foreground">
                     No transfers yet. Send your first transfer from the dashboard.
                   </TableCell>
                 </TableRow>

--- a/src/services/api/mocks/handlers.ts
+++ b/src/services/api/mocks/handlers.ts
@@ -54,6 +54,7 @@ const mockTransfers: Transfer[] = [
       country: 'Germany',
       bankName: 'Deutsche Bank',
     },
+    deliveryMethod: 'bank',
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
   },
@@ -75,6 +76,7 @@ const mockTransfers: Transfer[] = [
       country: 'Italy',
       bankName: 'Intesa Sanpaolo',
     },
+    deliveryMethod: 'bank',
     createdAt: new Date(Date.now() - 1000 * 60 * 60 * 5).toISOString(),
     updatedAt: new Date(Date.now() - 1000 * 60 * 60 * 5).toISOString(),
   },
@@ -96,6 +98,7 @@ const mockTransfers: Transfer[] = [
       country: 'India',
       bankName: 'HDFC Bank',
     },
+    deliveryMethod: 'cash',
     createdAt: new Date(Date.now() - 1000 * 60 * 60 * 2).toISOString(),
     updatedAt: new Date(Date.now() - 1000 * 60 * 60 * 2).toISOString(),
   },
@@ -324,7 +327,7 @@ export const handlers = [
 
   graphql.mutation('CreateTransfer', ({ variables }: { variables: { input: TransferRequest } }) => {
     const { input } = variables;
-    
+
     return HttpResponse.json({
       data: {
         createTransfer: {
@@ -334,6 +337,7 @@ export const handlers = [
           receiveAmount: input.sendAmount * 0.85,
           exchangeRate: 0.85,
           fee: input.sendAmount * 0.005,
+          deliveryMethod: input.deliveryMethod,
         },
       },
     });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -33,6 +33,8 @@ export interface Currency {
 }
 
 // Transfer types
+export type DeliveryMethod = 'bank' | 'card' | 'cash';
+
 export interface Transfer {
   id: string;
   fromCurrency: string;
@@ -45,6 +47,7 @@ export interface Transfer {
   status: 'pending' | 'processing' | 'completed' | 'failed';
   recipientId: string;
   recipientDetails?: TransferRecipient;
+  deliveryMethod: DeliveryMethod;
   createdAt: string;
   updatedAt: string;
 }
@@ -55,6 +58,7 @@ export interface TransferRequest {
   sendAmount: number;
   recipientId: string;
   recipientDetails?: TransferRecipient;
+  deliveryMethod: DeliveryMethod;
 }
 
 export interface ExchangeRate {


### PR DESCRIPTION
## Summary
- add a delivery method type to transfer interfaces so requests can carry the selection
- propagate the selected delivery method through the converter flow and mock handlers
- surface the delivery method in the transactions table for better visibility

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d96e77b9188324b354a929b232756f