### PR TITLE
Handle missing currency codes in transactions

### DIFF
--- a/src/pages/Transactions.tsx
+++ b/src/pages/Transactions.tsx
@@ -16,12 +16,27 @@ const statusVariant = {
   failed: "destructive" as const,
 };
 
-const formatCurrency = (value: number, currency: string) =>
-  new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency,
-    maximumFractionDigits: 2,
-  }).format(value);
+const formatCurrency = (value: number, currency?: string) => {
+  if (!currency) {
+    return new Intl.NumberFormat("en-US", {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(value);
+  }
+
+  try {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency,
+      maximumFractionDigits: 2,
+    }).format(value);
+  } catch (error) {
+    return new Intl.NumberFormat("en-US", {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(value);
+  }
+};
 
 const formatDate = (value: string) =>
   new Intl.DateTimeFormat("en-US", {
@@ -111,10 +126,12 @@ const Transactions = () => {
                       <div className="text-xs text-muted-foreground">{transfer.recipientDetails?.email}</div>
                     </TableCell>
                     <TableCell className="text-xs text-muted-foreground">
-                      {formatCurrency(transfer.sendAmount, transfer.fromCurrency)} {transfer.fromCurrency}
+                      {formatCurrency(transfer.sendAmount, transfer.fromCurrency)}
+                      {transfer.fromCurrency ? ` ${transfer.fromCurrency}` : ""}
                     </TableCell>
                     <TableCell className="text-xs text-muted-foreground">
-                      {formatCurrency(transfer.receiveAmount, transfer.toCurrency)} {transfer.toCurrency}
+                      {formatCurrency(transfer.receiveAmount, transfer.toCurrency)}
+                      {transfer.toCurrency ? ` ${transfer.toCurrency}` : ""}
                     </TableCell>
                     <TableCell className="text-xs text-muted-foreground">
                       <Badge variant="outline" className="capitalize">

--- a/src/services/api/mocks/handlers.ts
+++ b/src/services/api/mocks/handlers.ts
@@ -333,6 +333,8 @@ export const handlers = [
         createTransfer: {
           id: Date.now().toString(),
           status: 'pending',
+          fromCurrency: input.fromCurrency,
+          toCurrency: input.toCurrency,
           sendAmount: input.sendAmount,
           receiveAmount: input.sendAmount * 0.85,
           exchangeRate: 0.85,


### PR DESCRIPTION
## Summary
- allow the transactions currency formatter to handle missing or invalid currency codes gracefully
- adjust wallet and transfer table cells to append codes only when they exist
- include fromCurrency and toCurrency in the CreateTransfer GraphQL mock so UI data stays complete

## Testing
- npm run lint *(fails: existing `Unexpected any` warning in CurrencyConverter.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d97102c81c8324adefd4d844f8ba5a