### PR TITLE
Adjust transfer totals by delivery method

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -33,6 +33,8 @@ export interface Currency {
 }
 
 // Transfer types
+export type TransferMethod = 'bank' | 'card' | 'cash';
+
 export interface Transfer {
   id: string;
   fromCurrency: string;
@@ -43,6 +45,7 @@ export interface Transfer {
   fee: number;
   totalAmount: number;
   status: 'pending' | 'processing' | 'completed' | 'failed';
+  transferMethod: TransferMethod;
   recipientId: string;
   recipientDetails?: TransferRecipient;
   createdAt: string;
@@ -55,6 +58,9 @@ export interface TransferRequest {
   sendAmount: number;
   recipientId: string;
   recipientDetails?: TransferRecipient;
+  transferMethod: TransferMethod;
+  fee: number;
+  totalAmount: number;
 }
 
 export interface ExchangeRate {


### PR DESCRIPTION
## Summary
- derive transfer fee and total based on the selected delivery method in the currency converter UI
- include the method-specific fee and total in transfer creation payloads and completion messaging
- update mock API handlers to calculate fees/totals by delivery method and keep wallet/ledger data aligned

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d96e7a79b883249813590aea1bdacf