### PR TITLE
Remove redundant close control from transfer dialog

### DIFF
--- a/src/components/CurrencyConverter.tsx
+++ b/src/components/CurrencyConverter.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useMemo, useState } from "react";
-import { ArrowUpDown, Calculator, CheckCircle, Loader2, UserRound, CreditCard, Building2, Banknote, Shield, Clock, ArrowRight, X } from "lucide-react";
+import { ArrowUpDown, Calculator, CheckCircle, Loader2, UserRound, CreditCard, Building2, Banknote, Shield, Clock, ArrowRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -341,20 +341,10 @@ export const CurrencyConverter = () => {
       >
         <DialogContent className="max-w-md">
           <DialogHeader className="pb-2">
-            <div className="flex items-center justify-between">
-              <DialogTitle className="flex items-center gap-2 text-base">
-                <UserRound className="h-4 w-4 text-primary" />
-                Send {toCurrency} {receiveAmount}
-              </DialogTitle>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => setIsDialogOpen(false)}
-                className="h-6 w-6 p-0"
-              >
-                <X className="h-4 w-4" />
-              </Button>
-            </div>
+            <DialogTitle className="flex items-center gap-2 text-base">
+              <UserRound className="h-4 w-4 text-primary" />
+              Send {toCurrency} {receiveAmount}
+            </DialogTitle>
             <DialogDescription className="text-xs text-muted-foreground">
               Choose delivery method and enter recipient details
             </DialogDescription>


### PR DESCRIPTION
## Summary
- remove the manual header close control from the transfer dialog since DialogContent already renders a close button
- tidy imports after removing the extra close button

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d976aa6d6483248340ebf05dd6b99e