### PR TITLE
feat: support delivery-specific recipient details

### DIFF
--- a/src/services/api/mocks/handlers.ts
+++ b/src/services/api/mocks/handlers.ts
@@ -48,6 +48,7 @@ const mockTransfers: Transfer[] = [
     status: 'completed',
     recipientId: '1',
     recipientDetails: {
+      method: 'bank',
       name: 'Jane Smith',
       email: 'jane@example.com',
       accountNumber: 'DE89370400440532013000',
@@ -70,6 +71,7 @@ const mockTransfers: Transfer[] = [
     status: 'completed',
     recipientId: '2',
     recipientDetails: {
+      method: 'bank',
       name: 'Marco Rossi',
       email: 'marco@example.it',
       accountNumber: 'IT60X0542811101000000123456',
@@ -92,11 +94,12 @@ const mockTransfers: Transfer[] = [
     status: 'pending',
     recipientId: '3',
     recipientDetails: {
+      method: 'cash',
       name: 'Aisha Khan',
       email: 'aisha@example.in',
-      accountNumber: 'IN0987654321123456',
       country: 'India',
-      bankName: 'HDFC Bank',
+      pickupLocation: 'HDFC Bank Mumbai Central',
+      idNumber: 'ID99887766',
     },
     deliveryMethod: 'cash',
     createdAt: new Date(Date.now() - 1000 * 60 * 60 * 2).toISOString(),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -106,13 +106,36 @@ export interface LedgerEntry {
   createdAt: string;
 }
 
-export interface TransferRecipient {
+interface RecipientBase {
+  method: DeliveryMethod;
   name: string;
   email: string;
-  accountNumber: string;
   country: string;
+}
+
+export interface BankRecipientDetails extends RecipientBase {
+  method: 'bank';
+  accountNumber: string;
   bankName?: string;
 }
+
+export interface CardRecipientDetails extends RecipientBase {
+  method: 'card';
+  cardNumber: string;
+  expiryDate: string;
+  cvv: string;
+}
+
+export interface CashRecipientDetails extends RecipientBase {
+  method: 'cash';
+  pickupLocation: string;
+  idNumber: string;
+}
+
+export type TransferRecipient =
+  | BankRecipientDetails
+  | CardRecipientDetails
+  | CashRecipientDetails;
 
 export interface AccountState {
   wallet: WalletSummary | null;


### PR DESCRIPTION
## Summary
- define a discriminated union for transfer recipient details by delivery method
- send method-specific recipient payloads from the currency converter flow
- align MSW mock data with the new recipient structure so all delivery methods work

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d97aa210c0832491440cdf1d025e20