### PR TITLE
Update MSW enable flag behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ A modern, full-stack financial transfer application built with React, TypeScript
    ```bash
    npm run preview
    ```
+   - To keep payment simulation mocks when previewing, run `VITE_ENABLE_API_MOCKS=true npm run preview`
+   - When serving the production bundle with another tool, set `VITE_ENABLE_API_MOCKS=true` in the environment so MSW continues to power simulated payments
 
 ## 📋 Available Scripts
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,9 +5,11 @@ import App from './App.tsx';
 import { AppProviders } from './providers/AppProviders';
 import './index.css';
 
-// Start MSW in development when enabled
+// Start MSW when explicitly enabled or by default in development
+const enableMocksFlag = import.meta.env.VITE_ENABLE_API_MOCKS;
 const shouldEnableMocks =
-  import.meta.env.DEV && import.meta.env.VITE_ENABLE_API_MOCKS !== 'false';
+  enableMocksFlag === 'true' ||
+  (import.meta.env.DEV && enableMocksFlag !== 'false');
 
 if (shouldEnableMocks) {
   // Clear problematic cookies that might cause MSW serialization issues


### PR DESCRIPTION
## Summary
- allow MSW mocks to be enabled explicitly via VITE_ENABLE_API_MOCKS in any environment
- keep mocks enabled by default in development unless explicitly disabled
- document how to enable mocks when running preview or other production servers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9851348ac83249b05d19c7412c096